### PR TITLE
friendlier function name for stack traces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var types = [
 ];
 var draining;
 var queue = [];
-function drainQueue() {
+//named nextTick for less confusing stack traces
+function nextTick() {
   draining = true;
   var i, oldQueue;
   var len = queue.length;
@@ -28,7 +29,7 @@ var i = -1;
 var len = types.length;
 while (++ i < len) {
   if (types[i] && types[i].test && types[i].test()) {
-    scheduleDrain = types[i].install(drainQueue);
+    scheduleDrain = types[i].install(nextTick);
     break;
   }
 }


### PR DESCRIPTION
seeing a stack trace end in `nextTick` is going to be less confusing then seeing it end in `drainQueue`
