### PR TITLE
Check for process without potential to cause a ReferenceError.

### DIFF
--- a/lib/nextTick.js
+++ b/lib/nextTick.js
@@ -1,7 +1,7 @@
 'use strict';
 exports.test = function () {
   // Don't get fooled by e.g. browserify environments.
-  return process && !process.browser;
+  return (typeof process !== 'undefined') && !process.browser;
 };
 
 exports.install = function (func) {


### PR DESCRIPTION
I'm using immediate in a library that I build with Webpack. Since your `main` script is `lib/index.js`, this pulls `lib/nextTick.js` into the browser, which fails with a reference error when it tries to access `process`. This patch fixes the `process` check so it can't throw a reference error in this case.