### PR TITLE
Call functions with few arguments directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,17 @@ function Item(fun, array) {
   this.array = array;
 }
 Item.prototype.run = function () {
-  this.fun.apply(null, this.array);
+  var fun = this.fun;
+  var array = this.array;
+  switch (array.length) {
+    // Optimized common cases
+    case 0:  return fun();
+    case 1:  return fun(array[0]);
+    case 2:  return fun(array[0], array[1]);
+    case 3:  return fun(array[0], array[1], array[2]);
+    // Slower general case
+    default: return fun.apply(null, array);
+  }
 };
 module.exports = immediate;
 function immediate(task) {


### PR DESCRIPTION
This pull request improves performance by calling functions with few arguments directly, as [done in Node.js](https://github.com/nodejs/node/blob/v6.4.0/lib/timers.js#L335) and [proposed in the `setImmediate` shim](https://github.com/YuzuJS/setImmediate/pull/55).

**[Benchmark](https://gist.github.com/RubenVerborgh/63309e4cc6e611c5d636a1340f15682e)**

|                      | time on Node 6.3.1 (s) |
|-----------------------|-------------------:|
| current `master`      |               6.7 |
| this pull request     |                1.8 |